### PR TITLE
Fix argument validation for `.multiple()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default function randomItem(array) {
 }
 
 randomItem.multiple = (array, count) => {
-	if (!Number.isInteger(count) && count >= 0) {
+	if (!Number.isInteger(count) || (Number.isInteger(count) && count < 0)) {
 		throw new TypeError('Expected a non-negative integer');
 	}
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default function randomItem(array) {
 }
 
 randomItem.multiple = (array, count) => {
-	if (!Number.isInteger(count) || (Number.isInteger(count) && count < 0)) {
+	if (!(Number.isInteger(count) && count >= 0)) {
 		throw new TypeError('Expected a non-negative integer');
 	}
 

--- a/test.js
+++ b/test.js
@@ -12,8 +12,27 @@ test('main', t => {
 	}
 });
 
+test('main arg validation', t => {
+	t.throws(() => {
+		randomItem('a');
+	}, {
+		instanceOf: TypeError,
+		message: 'Expected an array'
+	});
+});
+
 test('.multiple()', t => {
 	const result = randomItem.multiple(fixture, 4);
 	t.is(result.length, 4);
 	t.true(result.every(value => fixture.includes(value)));
+});
+
+test('.multiple() arg validation', t => {
+	t.throws(() => {
+		randomItem.multiple(fixture, -1);
+		randomItem.multiple(fixture, 'a');
+	}, {
+		instanceOf: TypeError,
+		message: 'Expected a non-negative integer'
+	});
 });

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('main', t => {
 	}
 });
 
-test('main arg validation', t => {
+test('main - argument validation', t => {
 	t.throws(() => {
 		randomItem('a');
 	}, {
@@ -27,7 +27,7 @@ test('.multiple()', t => {
 	t.true(result.every(value => fixture.includes(value)));
 });
 
-test('.multiple() arg validation', t => {
+test('.multiple() - argument validation', t => {
 	t.throws(() => {
 		randomItem.multiple(fixture, -1);
 		randomItem.multiple(fixture, 'a');


### PR DESCRIPTION
- Argument validation in `.multiple()` was wrong.
- Added tests to cover argument validations for both functions.