### PR TITLE
Unnecessary map

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,5 @@ randomItem.multiple = (array, count) => {
 		throw new TypeError('Expected a non-negative integer');
 	}
 
-	return Array.from({length: count}, () => randomItem(array))
+	return Array.from({length: count}, () => randomItem(array));
 };

--- a/index.js
+++ b/index.js
@@ -11,5 +11,5 @@ randomItem.multiple = (array, count) => {
 		throw new TypeError('Expected a non-negative integer');
 	}
 
-	return Array.from({length: count}).map(() => randomItem(array));
+	return Array.from({length: count}, () => randomItem(array))
 };


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#parameters

We can directly pass a `mapFn`.